### PR TITLE
Proposal: Use types to encode legal states and transitions

### DIFF
--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -49,7 +49,7 @@ fn main() {
 
     // Initialize
     let timer = timer::SysTimer::new();
-    let (mut client, mut ingress) = espresso::EspClient::new(serial_tx, timer);
+    let (mut client, mut ingress) = espresso::client(serial_tx, timer);
 
     // Launch reading thread
     thread::Builder::new()
@@ -82,10 +82,10 @@ fn main() {
     println!("OK");
 
     // Get firmware information
-    let version = client
+    /*let version = client
         .get_firmware_version()
         .expect("Could not get firmware version");
-    println!("{:?}", version);
+    println!("{:?}", version);*/
 
     // Show current config
     let wifi_mode = client.get_wifi_mode().expect("Could not get wifi mode");
@@ -96,8 +96,8 @@ fn main() {
 
     println!();
     print!("Setting current Wifi mode to Station… ");
-    client
-        .set_wifi_mode(WifiMode::Station, false)
+    let mut client = client
+        .set_station_mode(false)
         .expect("Could not set current wifi mode");
     println!("OK");
 
@@ -112,23 +112,16 @@ fn main() {
     println!("Local MAC: {}", local_addr.mac);
     println!("Local IP:  {:?}", local_addr.ip);
 
-    match status {
-        ConnectionStatus::ConnectedToAccessPoint | ConnectionStatus::TransmissionEnded => {
-            println!("Already connected!");
-        }
-        _ => {
-            println!();
-            println!("Connecting to access point with SSID {:?}…", ssid);
-            let result = client
-                .join_access_point(ssid.as_str(), psk.as_str(), false)
-                .expect("Could not connect to access point");
-            println!("{:?}", result);
-            let status = client
-                .get_connection_status()
-                .expect("Could not get connection status");
-            println!("Connection status: {:?}", status);
-        }
-    }
+    println!("Connecting to access point with SSID {:?}…", ssid);
+    let mut client = client
+        .join_access_point(ssid.as_str(), psk.as_str(), false)
+        .expect("Could not connect to access point");
+
+    let status = client
+        .get_connection_status()
+        .expect("Could not get connection status");
+    println!("Connection status: {:?}", status);
+
     println!(
         "Local IP: {:?}",
         client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! A crate to use ESP8266 WiFi modules over a serial connection.
 
 use atat::AtatClient;
+use core::marker::PhantomData;
 use embedded_hal::serial;
 use embedded_hal::timer;
 use heapless::String;
@@ -14,34 +15,61 @@ use types::ConfigWithDefault;
 /// Type alias for a result that may return an ATAT error.
 pub type EspResult<T> = Result<T, nb::Error<atat::Error>>;
 
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum Mode {
+    StationMode,
+    APMode,
+    StationAndAPMode,
+}
+
+pub struct UnknownMode {}
+pub struct StationMode<MODE> {
+    _mode: PhantomData<MODE>,
+}
+
+pub struct APConnected<LINK> {
+    _mode: PhantomData<LINK>,
+}
+pub struct APDisconnected {}
+
+pub struct LinkConnected {}
+pub struct LinkDisconnected {}
+
+/// Create a new ESP8266 client.
+///
+/// Together with the client, an [`IngressManager`][IngressManager] will be
+/// returned. That needs to be hooked up with the incoming serial bytes.
+///
+/// [IngressManager]: ../atat/istruct.IngressManager.html
+pub fn client<TX, TIMER>(serial_tx: TX, timer: TIMER) -> (EspClient<TX, TIMER, UnknownMode>, atat::IngressManager)
+where
+    TX: serial::Write<u8>,
+    TIMER: timer::CountDown,
+    TIMER::Time: From<u32>,
+{
+    let config = atat::Config::new(atat::Mode::Timeout);
+    let (client, ingress) = atat::new(serial_tx, timer, config);
+    (EspClient { client, _mode: PhantomData }, ingress)
+}
+
+
 /// An ESP8266 client.
-pub struct EspClient<TX, TIMER>
+pub struct EspClient<TX, TIMER, MODE>
 where
     TX: serial::Write<u8>,
     TIMER: timer::CountDown,
     TIMER::Time: From<u32>,
 {
     client: atat::Client<TX, TIMER>,
+    _mode: PhantomData<MODE>,
 }
 
-impl<TX, TIMER> EspClient<TX, TIMER>
+impl<TX, TIMER, MODE> EspClient<TX, TIMER, MODE>
 where
     TX: serial::Write<u8>,
     TIMER: timer::CountDown,
     TIMER::Time: From<u32>,
 {
-    /// Create a new ESP8266 client.
-    ///
-    /// Together with the client, an [`IngressManager`][IngressManager] will be
-    /// returned. That needs to be hooked up with the incoming serial bytes.
-    ///
-    /// [IngressManager]: ../atat/istruct.IngressManager.html
-    pub fn new(serial_tx: TX, timer: TIMER) -> (Self, atat::IngressManager) {
-        let config = atat::Config::new(atat::Mode::Timeout);
-        let (client, ingress) = atat::new(serial_tx, timer, config);
-        (Self { client }, ingress)
-    }
-
     /// Send a raw command to the device.
     pub fn send_command<T>(&mut self, command: &T) -> EspResult<T::Response>
     where
@@ -87,15 +115,13 @@ where
             .map(|_: responses::EmptyResponse| ())
     }
 
-    /// Join the specified access point.
-    pub fn join_access_point(
-        &mut self,
-        ssid: impl Into<String<heapless::consts::U32>>,
-        psk: impl Into<String<heapless::consts::U64>>,
-        persist: bool,
-    ) -> EspResult<responses::JoinResponse> {
+    /// Sets  WiFi mode to station mode.
+    pub fn set_station_mode(mut self, persist: bool) -> EspResult<EspClient<TX, TIMER, StationMode<APDisconnected>>> {
         self.client
-            .send(&requests::JoinAccessPoint::new(ssid, psk, persist))
+            .send(&requests::SetWifiMode::to(types::WifiMode::Station, persist))
+            .map(|_: responses::EmptyResponse| ())?;
+
+        Ok(EspClient { client: self.client, _mode: PhantomData})
     }
 
     /// Return the current connection status.
@@ -106,5 +132,25 @@ where
     /// Return the locally assigned IP and MAC address.
     pub fn get_local_address(&mut self) -> EspResult<responses::LocalAddress> {
         self.client.send(&requests::GetLocalAddress)
+    }
+}
+
+impl<TX, TIMER> EspClient<TX, TIMER, StationMode<APDisconnected>>
+where
+    TX: serial::Write<u8>,
+    TIMER: timer::CountDown,
+    TIMER::Time: From<u32>,
+{
+    /// Join the specified access point.
+    pub fn join_access_point(
+        mut self,
+        ssid: impl Into<String<heapless::consts::U32>>,
+        psk: impl Into<String<heapless::consts::U64>>,
+        persist: bool,
+    ) -> EspResult<EspClient<TX, TIMER, StationMode<APConnected<LinkDisconnected>>>> {
+        self.client
+            .send(&requests::JoinAccessPoint::new(ssid, psk, persist))?;
+
+        Ok(EspClient { client: self.client, _mode: PhantomData })
     }
 }


### PR DESCRIPTION
I think it would be good to use types to encode state specific methods and transitions between state similar to how embedded_hal does it and guard users from illegal state transitions.

What do you think?