### PR TITLE
Passive receive mode

### DIFF
--- a/src/commands/responses.rs
+++ b/src/commands/responses.rs
@@ -71,3 +71,15 @@ pub enum ConnectResponse {
 }
 
 impl AtatResp for ConnectResponse {}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SendDataResponse {
+    /// Data transmitted successfully
+    Ok,
+    /// Data transmission failed
+    Failed,
+    /// Connection not established or disrupted during transmission
+    Error,
+}
+
+impl AtatResp for SendDataResponse {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod commands;
 pub mod types;
 
 use commands::{requests, responses};
-use types::ConfigWithDefault;
+use types::{ConfigWithDefault, TcpReceiveMode};
 
 /// Type alias for a result that may return an ATAT error.
 pub type EspResult<T, E> = Result<T, nb::Error<atat::Error<E>>>;
@@ -133,5 +133,12 @@ where
     /// Return the locally assigned IP and MAC address.
     pub fn get_local_address(&mut self) -> EspResult<responses::LocalAddress, GenericError> {
         self.client.send(&requests::GetLocalAddress)
+    }
+
+    /// Set TCP Receive mode
+    pub fn set_tcp_receive_mode(&mut self, mode: TcpReceiveMode) -> EspResult<(), GenericError> {
+        self.client
+            .send(&requests::SetTcpReceiveMode::to(mode))
+            .map(|_: responses::EmptyResponse| ())
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -89,3 +89,24 @@ impl Protocol {
         }
     }
 }
+
+/// The TCP receive mode.
+#[derive(Debug)]
+pub enum TcpReceiveMode {
+    /// Active mode: ESP8266 will send all the received TCP data instantly to
+    /// host MCU through UART with header "+IPD".
+    Active,
+    /// Passive mode: ESP8266 will keep the received TCP data in an internal
+    /// buffer (default is 2920 bytes), and wait for host MCU to read the data.
+    /// If the buffer is full, the TCP transmission will be blocked.
+    Passive,
+}
+
+impl TcpReceiveMode {
+    pub(crate) fn as_at_str(&self) -> &'static str {
+        match self {
+            Self::Active => "0",
+            Self::Passive => "1",
+        }
+    }
+}


### PR DESCRIPTION
This should simplify URCs (see #7).

TODO: Use a custom OK and error handler to handle `SEND OK` and `SEND FAILED`.

Blocked by an atat upgrade.